### PR TITLE
Fix AltManagerMixin.js to use displayName

### DIFF
--- a/AltManagerMixin.js
+++ b/AltManagerMixin.js
@@ -64,8 +64,8 @@ var AltManagerMixin = {
       throw new ReferenceError('registerAction has not been is defined')
     }
 
-    var storeName = Store.name
-    var actionName = Action.name
+    var storeName = Store.displayName || Store.name
+    var actionName = Action.displayName || Action.name
 
     this.action = props.alt.getActions(actionName)
     this.store = props.alt.getStore(storeName)
@@ -73,7 +73,7 @@ var AltManagerMixin = {
     if (!this.action) {
       props.alt.addActions(actionName, Action)
       this.action = props.alt.getActions(actionName)
-      this.store = props.alt.createStore(Store, null, props.alt)
+      this.store = props.alt.createStore(Store, storeName, props.alt)
       if (this.onNewAlt) {
         this.onNewAlt(this.store.getState(), props)
       }


### PR DESCRIPTION
`Alt` documents are careful to warn people to define a `displayName` in their stores, but this mixin was not using `displayName`. I came to this fix in two stages:

First, the `null` second argument to [alt.createStore](https://github.com/altjs/mixins/blob/1fb7c6f3aec808ccf4371eb7dba0fdc8effeb8c4/AltManagerMixin.js#L76) was causing a crash on minification. I'm not sure why, but changing it to `storeName` fixed the crash. I'm not sure why I didn't propose a PR at the time (about six months ago), but it's just as well, because the change introduced another bug that was harder to spot. Because now it was not using `displayName`, the key for the store in the snapshot was changing, so whenever the app was restarted with a new minified bundle, it could not find the snapshot to bootstrap from. In normal operation this problem was masked by redundant information from another store so it took a while to track it down. 

This fix forces the use of `displayName`, if available, everywhere and seems to fix both problems.
